### PR TITLE
Restart loolwsd at update event

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -11,4 +11,5 @@ event_actions($event, qw(
 
 event_services($event, qw(
                httpd reload
+               loolwsd restart
 ));


### PR DESCRIPTION
Just suggestion a suggestion regarding chaining the password, toy could opt for restarting loolwsd with every nethserver-collabora-update event.  Looks like loolwsd read the xml config at start up, it can make sense to restart it by default. 




